### PR TITLE
allow java -version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: install Rust stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.79.0
     - name: install dependencies (ubuntu only)
       if: matrix.platform == 'ubuntu-latest'
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,12 +70,14 @@ jobs:
     - name: Cargo test
       uses: actions-rs/cargo@v1
       with:
+        toolchain: 1.79.0
         command: test
         args: --manifest-path src-tauri/Cargo.toml
 
     - name: Cargo build
       uses: actions-rs/cargo@v1
       with:
+        toolchain: 1.79.0
         command: build
         args: --release --manifest-path src-tauri/Cargo.toml
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: install Rust stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.79.0
     - name: install dependencies (ubuntu only)
       run: |
         sudo apt-get update
@@ -65,7 +65,7 @@ jobs:
     - name: install Rust stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: 1.79.0
 
     - name: Cargo test
       uses: actions-rs/cargo@v1

--- a/src-tauri/rust-toolchain.toml
+++ b/src-tauri/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.79.0"

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -25,12 +25,22 @@ export const CHECK_OR_CREATE_EULA: CheckId = 'check-or-create-eula'
 
 export const checkRegistry: CheckRegistry = {
   [CHECK_JAVA_VERSION]: async () => {
-    const output = await new Command('run-java', ['--version']).execute()
-    if (output.code !== 0) {
-      const message = `test exited with non-zero code: ${output.code}, stderr: ${output.stderr}`
+    const output_new = await new Command('run-java', ['--version']).execute()
+    const output_old = await new Command('run-java', ['-version']).execute()
+    if (output_new.code !== 0 && output_old.code !== 0) {
+      const message = `
+       'java --version' exited with non-zero code: ${output_new.code}, stderr: ${output_new.stderr}
+       'java -version' exited with non-zero code: ${output_old.code}, stderr: ${output_old.stderr}
+       `
       throw new StatusCodeError(message)
     }
-    return output.stdout
+
+    if (output_new.code === 0) {
+      return output_new.stdout
+    } else {
+      // old java print versions on stderr
+      return output_old.stderr
+    }
   },
   [CHECK_SH_VERSION]: async () => {
     const output = await new Command('run-sh', ['--version']).execute()


### PR DESCRIPTION
Old Java only accept `java -version`, not `java --version`.
Note that `java -version` print version info to stderr.

This patch allow java check whether `java --version` or `java -version` succeed.


example: 
```
% java -version 1>/dev/null
java version "1.8.0_421"
Java(TM) SE Runtime Environment (build 1.8.0_421-b09)
Java HotSpot(TM) 64-Bit Server VM (build 25.421-b09, mixed mode)
```