### PR TITLE
Fix bedrock server not work on Windows

### DIFF
--- a/docs/_layouts/landing.html
+++ b/docs/_layouts/landing.html
@@ -134,7 +134,7 @@
             <div class="row justify-content-md-center gy-4">
                 <div class="col-md-3">
                     <a
-                        href="https://github.com/Kumassy/ownserver-client-gui/releases/download/app-v0.10.0/ownserver-client-gui_0.10.0_x64_en-US.msi"
+                        href="https://github.com/Kumassy/ownserver-client-gui/releases/download/app-v0.10.1/ownserver-client-gui_0.10.1_x64_en-US.msi"
                         class="btn btn-primary"
                     >
                         {% t landing.download.windows %}
@@ -142,7 +142,7 @@
                 </div>
                 <div class="col-md-3">
                     <a
-                        href="https://github.com/Kumassy/ownserver-client-gui/releases/download/app-v0.10.0/ownserver-client-gui_0.10.0_aarch64.dmg"
+                        href="https://github.com/Kumassy/ownserver-client-gui/releases/download/app-v0.10.1/ownserver-client-gui_0.10.1_aarch64.dmg"
                         class="btn btn-primary"
                     >
                         {% t landing.download.macos %}
@@ -150,7 +150,7 @@
                 </div>
                 <div class="col-md-3">
                     <a
-                        href="https://github.com/Kumassy/ownserver-client-gui/releases/download/app-v0.10.0/ownserver-client-gui_0.10.0_amd64.AppImage"
+                        href="https://github.com/Kumassy/ownserver-client-gui/releases/download/app-v0.10.1/ownserver-client-gui_0.10.1_amd64.AppImage"
                         class="btn btn-primary"
                     >
                         {% t landing.download.linux %}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ownserver-client-gui",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "dependencies": {
     "@brianmcallister/react-auto-scroll": "^1.1.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3082,7 +3082,7 @@ dependencies = [
 
 [[package]]
 name = "ownserver-client-gui"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "futures",
  "lazy_static",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ownserver-client-gui"
-version = "0.10.0"
+version = "0.10.1"
 description = "OwnServer Client GUI"
 authors = ["Kumassy"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "package": {
     "productName": "ownserver-client-gui",
-    "version": "0.10.0"
+    "version": "0.10.1"
   },
   "build": {
     "distDir": "../build",

--- a/src/features/localSlice.ts
+++ b/src/features/localSlice.ts
@@ -264,8 +264,6 @@ const getCommand = async (rootState: RootState) => {
   switch(args[0]) {
     case 'java':
     case 'docker':
-    case 'bedrock_server':
-    case 'bedrock_server.exe':
       return new Command(args[0], args.splice(1), spawnOptions)
     default:
       if (osType === 'Windows_NT') {


### PR DESCRIPTION
0.10.0 tries to use native command for bedrock_server, but can't work with tauri permission system.
Revert use of native command.